### PR TITLE
Don't run regex every tick for every entity

### DIFF
--- a/src/main/java/com/fantasticsource/dynamicstealth/DynamicStealth.java
+++ b/src/main/java/com/fantasticsource/dynamicstealth/DynamicStealth.java
@@ -131,7 +131,11 @@ public class DynamicStealth
     @SubscribeEvent
     public static void saveConfig(ConfigChangedEvent.OnConfigChangedEvent event)
     {
-        if (event.getModID().equals(MODID)) ConfigManager.sync(MODID, Config.Type.INSTANCE);
+        if (event.getModID().equals(MODID))
+        {
+            ConfigManager.sync(MODID, Config.Type.INSTANCE);
+            Compat.init();
+        }
     }
 
     @SubscribeEvent
@@ -804,6 +808,7 @@ public class DynamicStealth
     public void postInit(FMLPostInitializationEvent event)
     {
         //Compat init
+        Compat.init();
         if (Loader.isModLoaded("neat")) Compat.neat = true;
         if (Loader.isModLoaded("testdummy")) Compat.testdummy = true;
         if (Loader.isModLoaded("statues")) Compat.statues = true;

--- a/src/main/java/com/fantasticsource/dynamicstealth/compat/Compat.java
+++ b/src/main/java/com/fantasticsource/dynamicstealth/compat/Compat.java
@@ -1,16 +1,20 @@
 package com.fantasticsource.dynamicstealth.compat;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+
 import com.fantasticsource.dynamicstealth.config.DynamicStealthConfig;
 import com.fantasticsource.dynamicstealth.server.ai.edited.AIAttackMeleeEdit;
 import com.fantasticsource.mctools.NPEAttackTargetTaskHolder;
-import com.fantasticsource.tools.Tools;
+
+import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.ai.EntityAIAttackMelee;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.entity.ai.EntityAITasks.EntityAITaskEntry;
 import net.minecraftforge.fml.common.Loader;
-
-import java.util.Set;
 
 public class Compat
 {
@@ -22,12 +26,28 @@ public class Compat
             conarm = false,
             testdummy = false;
 
+    public static void init()
+    {
+        final String[] addNullChecksToAI = DynamicStealthConfig.serverSettings.ai.addNullChecksToAI;
+        ArrayList<String> names = new ArrayList<>(addNullChecksToAI.length);
+        for (String entry : addNullChecksToAI)
+        {
+            entry = entry.trim();
+            int commaIndex = entry.indexOf(',');
+            if (commaIndex == -1 || commaIndex + 1 > entry.length() || !Loader.isModLoaded(entry.substring(0, commaIndex).trim())) continue;
+            
+            names.add(entry.substring(commaIndex + 1));
+        }
+        classNamesToCheck = names.toArray(new String[names.size()]);
+        badNullTarget.clear();
+    }
+    
 
     public static void cancelTasksRequiringAttackTarget(EntityAITasks tasks)
     {
         for (EntityAITasks.EntityAITaskEntry task : tasks.taskEntries)
         {
-            if (badNullTargetHandling(task.action))
+            if (hasBadNullTargetHandling(task.action))
             {
                 //Hard reset; set using to false, call resetTask(), and remove task from executingTasks
                 task.using = false;
@@ -37,48 +57,68 @@ public class Compat
         }
     }
 
-
-    private static boolean badNullTargetHandling(EntityAIBase ai)
+    private static String[] classNamesToCheck;
+    // Value of 1 indicates that the corresponding EntityAIBase has bad null targeting.
+    private static Object2ByteOpenHashMap<Class<? extends EntityAIBase>> badNullTarget = new Object2ByteOpenHashMap<>();
+    {
+    	badNullTarget.defaultReturnValue((byte) -1);
+    }
+    
+    private static boolean hasBadNullTargetHandling(EntityAIBase ai)
     {
         if (ai instanceof EntityAIAttackMelee && !(ai instanceof AIAttackMeleeEdit)) return true;
+        if (classNamesToCheck.length == 0 || ai instanceof NPEAttackTargetTaskHolder) return false;
 
-        String aiClassname = ai.getClass().getName();
-        for (String entry : DynamicStealthConfig.serverSettings.ai.addNullChecksToAI)
-        {
-            String[] tokens = Tools.fixedSplit(entry, ",");
-            if (tokens.length != 2) continue;
-            if (!Loader.isModLoaded(tokens[0].trim())) continue;
+        Class<? extends EntityAIBase> aiClass = ai.getClass();
+        byte value = badNullTarget.getByte(aiClass);
+        if (value != badNullTarget.defaultReturnValue())
+            return value == (byte) 1; 
+        
+        String aiClassName = aiClass.getName();
+        for (String str : classNamesToCheck)
+            if (aiClassName.contains(str))
+            {
+                badNullTarget.put(aiClass, (byte) 1);
+                return true;
+            }
 
-            if (aiClassname.contains(tokens[1].trim())) return true;
-        }
-
+        badNullTarget.put(aiClass, (byte) 0);
         return false;
     }
 
-
     public static void replaceNPEAttackTargetTasks(EntityLiving living)
     {
-        EntityAITasks taskList = living.targetTasks;
-        Set<EntityAITasks.EntityAITaskEntry> entrySet = taskList.taskEntries;
-        for (EntityAITasks.EntityAITaskEntry task : entrySet.toArray(new EntityAITasks.EntityAITaskEntry[0]))
+        scanTasksForBadTargetHandling(living, living.targetTasks);
+        scanTasksForBadTargetHandling(living, living.tasks);
+    }
+    
+    private static ObjectArrayList<EntityAITasks.EntityAITaskEntry> entityAIStack = new ObjectArrayList<>();
+    
+    private static void scanTasksForBadTargetHandling(EntityLiving living, EntityAITasks taskList)
+    {
+        Iterator<EntityAITasks.EntityAITaskEntry> iterator = taskList.taskEntries.iterator();
+        while (iterator.hasNext())
         {
-            if (badNullTargetHandling(task.action))
+            EntityAITaskEntry task = iterator.next();
+            if (hasBadNullTargetHandling(task.action))
             {
-                taskList.addTask(task.priority, new NPEAttackTargetTaskHolder(living, task.action));
-                taskList.removeTask(task.action);
+                if (task.using)
+                {
+                    task.using = false;
+                    task.action.resetTask();
+                    taskList.executingTaskEntries.remove(task);
+                }
+                iterator.remove();
+                entityAIStack.push(task);
             }
         }
-
-        taskList = living.tasks;
-        entrySet = taskList.taskEntries;
-        for (EntityAITasks.EntityAITaskEntry task : entrySet.toArray(new EntityAITasks.EntityAITaskEntry[0]))
+        
+        while (!entityAIStack.isEmpty())
         {
-            if (badNullTargetHandling(task.action))
-            {
-                taskList.addTask(task.priority, new NPEAttackTargetTaskHolder(living, task.action));
-                taskList.removeTask(task.action);
-            }
+            EntityAITasks.EntityAITaskEntry task = entityAIStack.pop();
+            taskList.addTask(task.priority, new NPEAttackTargetTaskHolder(living, task.action));
         }
+        // Should never return before entityAIStack is empty.
     }
 
     public static void clearAttackTargetAndReplaceAITasks(EntityLiving living)


### PR DESCRIPTION
Closes #101 

I think it's safe to replace [Compat.clearAttackTargetAndReplaceAITasks(searcher);](https://github.com/Laike-Endaril/Dynamic-Stealth/blob/1dd46e3c7a40b58e6690aff098b170d17372bb73/src/main/java/com/fantasticsource/dynamicstealth/server/ai/AIDynamicStealth.java#L237) in `AIDynamicStealth` with `searcher.setAttackTarget(null);` because `cancelTasksRequiringAttackTarget(searcher.tasks);` will clear any bad tasks anyway. This would further improve performance.